### PR TITLE
Update to JDK 25 across workflows, project configuration, and Docker …

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,9 +27,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v4
-      name: Set up JDK 21
+      name: Set up JDK 25
       with:
-        java-version: '21'
+        java-version: '25'
         distribution: 'temurin'
         architecture: x64
         cache: 'maven'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jre-ubi10-minimal
+FROM eclipse-temurin:25-jre-ubi10-minimal
 
 ENV RUN_USER=java-runner
 ENV RUN_GROUP=${RUN_USER}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project is a Quarkus framework based, 'ready-to-play' micro-service.
 
 | Name           | Version |
 |----------------|---------|
-| Java           | 21      |
+| Java           | 25      |
 | Maven          | 3.8.1+  |
 | Quarkus        | 3.30.1  |
 | PostgreSQL     | 17.6    |

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jre-alpine-3.22
+FROM eclipse-temurin:25-jre-alpine-3.22
 
 ENV RUN_USER=java-runner
 ENV RUN_GROUP=${RUN_USER}

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
     <properties>
         <!-- Project -->
-        <java.version>21</java.version>
+        <java.version>25</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <argLine/>
 
@@ -285,7 +285,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven.surefire.plugin.version}</version>
                 <configuration>
-                    <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+                    <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar} --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <maven.home>${maven.home}</maven.home>


### PR DESCRIPTION
Update to JDK 25 across workflows, project configuration, and Docker images:

- `.github/workflows/maven.yml`: Set up JDK 25
- `pom.xml`: Bump `java.version` to 25 and adjust `argLine` for `mockito-core`
- `README.md`: Reflect JDK 25 in compatibility table
- `Dockerfile`: Use `eclipse-temurin:25-jre-ubi10-minimal`
- `alpine.Dockerfile`: Use `eclipse-temurin:25-jre-alpine-3.22`